### PR TITLE
Add JSON output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # quotes
 
 Use the source, Luke! ☺
+
+## Usage
+
+To print a random quote, use the following command:
+
+```
+$ quote
+Quiet people have the loudest minds.
+    - Richard Feynman
+```
+
+### Options
+
+- `-n`: Number of results to return (default is 1)
+- `--json`: Output in JSON format
+
+### JSON Example
+
+
+```
+$ quote --json
+```
+
+Example JSON output:
+```json
+[
+  {
+    "text": "Quiet people have the loudest minds.",
+    "author": "Richard Feynman"
+  }
+]
+```

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -12,8 +13,30 @@ import (
 //go:generate go run gen_quotes.go
 //go:generate go fmt quotes.go
 
+type Quote struct {
+	Text   string `json:"text"`
+	Author string `json:"author"`
+}
+
+func printJSON(quotes []string) {
+	var jsonQuotes []Quote
+	for _, q := range quotes {
+		parts := strings.Split(q, "\n")
+		text := strings.Join(parts[:len(parts)-1], " ")
+		author := strings.TrimPrefix(parts[len(parts)-1], "    - ")
+		jsonQuotes = append(jsonQuotes, Quote{Text: text, Author: author})
+	}
+	jsonData, err := json.MarshalIndent(jsonQuotes, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(jsonData))
+}
+
 func main() {
 	var count int
+	var jsonOutput bool
 	flag.Usage = func() {
 		name := path.Base(os.Args[0])
 		fmt.Fprintf(os.Stderr, "usage: %s [options]\n", name)
@@ -21,6 +44,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.IntVar(&count, "n", 1, "number of results to return")
+	flag.BoolVar(&jsonOutput, "json", false, "output in JSON format")
 	flag.Parse()
 
 	if flag.NArg() > 1 {
@@ -51,8 +75,14 @@ func main() {
 	})
 
 	n := min(count, len(quotes))
-	for i := range n {
-		fmt.Println(quotes[i])
-		fmt.Println()
+	selectedQuotes := quotes[:n]
+
+	if jsonOutput {
+		printJSON(selectedQuotes)
+	} else {
+		for _, q := range selectedQuotes {
+			fmt.Println(q)
+			fmt.Println()
+		}
 	}
 }


### PR DESCRIPTION
Related to #2

Add a `--json` command line switch to format the output in JSON.

* **main.go**:
  - Add a `--json` flag to the command line options.
  - Add a new function `printJSON` to format the output in JSON.
  - Modify the main function to check for the `--json` flag and call `printJSON` if set.
  - Ensure the JSON output matches the example provided in the issue description.

* **README.md**:
  - Update the usage instructions to include the new `--json` flag.
  - Provide an example of the JSON output format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tebeka/quote/issues/2?shareId=e00b5eed-1d31-4ab4-b600-83ece1a94a21).